### PR TITLE
Add a Cleo command to classify a Push

### DIFF
--- a/citools/console/commands/push.py
+++ b/citools/console/commands/push.py
@@ -29,7 +29,11 @@ class ClassifyCommand(Command):
 
     def handle(self):
         push = Push(self.argument("rev"), self.argument("branch"))
-        print(push.classify())
+        classification = push.classify()
+        self.line(
+            f'Push associated with the head revision {self.argument("rev")} on the branch '
+            f'{self.argument("branch")} is classified as {classification.name}'
+        )
 
 
 class PushCommands(Command):

--- a/citools/console/commands/push.py
+++ b/citools/console/commands/push.py
@@ -1,4 +1,5 @@
 from cleo import Command
+from mozci.push import Push
 
 from citools.dump_failures import dump_failures
 
@@ -8,6 +9,7 @@ class PushFailuresCommand(Command):
     Display failing tests for a given push.
 
     failures
+        {branch : Branch the push belongs to (e.g autoland, try, etc).}
     """
 
     def handle(self):
@@ -17,16 +19,28 @@ class PushFailuresCommand(Command):
         )
 
 
+class ClassifyCommand(Command):
+    """
+    Display the classification for a given push as GOOD, BAD or UNKNOWN.
+
+    classify
+        {branch=mozilla-central : Branch the push belongs to (e.g autoland, try, etc).}
+    """
+
+    def handle(self):
+        push = Push(self.argument("rev"), self.argument("branch"))
+        print(push.classify())
+
+
 class PushCommands(Command):
     """
     Contains commands that operate on a single push.
 
     push
-        {branch : Branch the push belongs to (e.g autoland, try, etc).}
         {rev : Head revision of the push.}
     """
 
-    commands = [PushFailuresCommand()]
+    commands = [PushFailuresCommand(), ClassifyCommand()]
 
     def handle(self):
         return self.call("help", self._config.name)


### PR DESCRIPTION
Requires https://github.com/mozilla/mozci/pull/526   
:warning: Please, do not merge until https://github.com/mozilla/mozci/pull/526 is merged, we won't be able to get `Push.classify` otherwise.

Closes #15 