### PR TITLE
Support web-platform-tests in dump_failures

### DIFF
--- a/citools/dump_failures.py
+++ b/citools/dump_failures.py
@@ -56,7 +56,10 @@ def update_results(task):
                 manifest = manifests[test]
             except KeyError:
                 try:
-                    manifest = manifests[f"browser/{test}"]
+                    if data["source"] == "web-platform-tests":
+                        manifest = f"testing/web-platform/meta/{test}.ini"
+                    else:
+                        manifest = manifests[f"browser/{test}"]
                 except KeyError:
                     logger.warning(f"Invalid test: {test}")
                     continue


### PR DESCRIPTION
Supports web-platform-tests for #7 
For example, for the test `/FileAPI/file/send-file-form-x-user-defined.html`, the corresponding .ini file will be
`testing/web-platform/meta/FileAPI/file/send-file-form-x-user-defined.html.ini`
